### PR TITLE
Re-export Data.Traversable.all

### DIFF
--- a/src/Whine/Prelude.purs
+++ b/src/Whine/Prelude.purs
@@ -27,7 +27,7 @@ import Data.Nullable (Nullable) as Reexport
 import Data.Profunctor (dimap) as Reexport
 import Data.String (Pattern(..), Replacement(..), joinWith) as Reexport
 import Data.String.NonEmpty (NonEmptyString) as Reexport
-import Data.Traversable (any, fold, for, for_, intercalate, traverse, traverse_, sequence, sequence_) as Reexport
+import Data.Traversable (all, any, fold, for, for_, intercalate, traverse, traverse_, sequence, sequence_) as Reexport
 import Data.Tuple (Tuple(..), fst, snd) as Reexport
 import Data.Tuple.Nested (type (/\), (/\)) as Reexport
 


### PR DESCRIPTION
Where `any` is re-exported, one might expect to find `all`, but this is not the case here, an import of Data.Traversable (all) is required to use in whine rules. This commit fixes that gap.