### PR TITLE
Fix vscode-languageserver node import for v10 exports map

### DIFF
--- a/src/Whine/Vscode/Server/Connection.js
+++ b/src/Whine/Vscode/Server/Connection.js
@@ -1,4 +1,4 @@
-import LS from 'vscode-languageserver/node.js'
+import LS from 'vscode-languageserver/node'
 
 export const createConnection_ = () => LS.createConnection(LS.ProposedFeatures.all)
 

--- a/src/Whine/Vscode/Server/TextDocuments.js
+++ b/src/Whine/Vscode/Server/TextDocuments.js
@@ -1,4 +1,4 @@
-import LS from 'vscode-languageserver/node.js'
+import LS from 'vscode-languageserver/node'
 import { TextDocument } from 'vscode-languageserver-textdocument'
 
 export const create_ = () => new LS.TextDocuments(TextDocument)


### PR DESCRIPTION
vscode-languageserver 10.0.0 introduced an exports map that only exposes the node entry under the ./node subpath. The FFI imported it as vscode-languageserver/node.js, which is not a key in the exports map, so esbuild fails to bundle:

```
  Could not resolve "vscode-languageserver/node.js"
  The path "./node.js" is not exported by package "vscode-languageserver"
```

Because the package declares no dependency pin, the whine bootstrap npm install resolves the latest vscode-languageserver (now 10.x), breaking the cached-bundle build for every consumer.

Drop the .js suffix so the import matches the ./node export key. This resolves on v10 (matches ./node) and stays compatible with v9.0.1 (no exports map; resolves to the root node.js file).